### PR TITLE
Revert "Bump sinatra from 3.1.0 to 4.1.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,21 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    base64 (0.2.0)
-    logger (1.6.1)
-    mustermann (3.0.3)
+    mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.7.3)
     puma (6.4.3)
       nio4r (~> 2.0)
-    rack (3.1.8)
-    rack-protection (4.1.0)
-      base64 (>= 0.1.0)
-      logger (>= 1.6.0)
-      rack (>= 3.0.0, < 4)
-    rack-session (2.0.0)
-      rack (>= 3.0.0)
+    rack (2.2.8.1)
+    rack-protection (3.1.0)
+      rack (~> 2.2, >= 2.2.4)
     ruby2_keywords (0.0.5)
-    sinatra (4.1.0)
-      logger (>= 1.6.0)
+    sinatra (3.1.0)
       mustermann (~> 3.0)
-      rack (>= 3.0.0, < 4)
-      rack-protection (= 4.1.0)
-      rack-session (>= 2.0.0, < 3)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.1.0)
       tilt (~> 2.0)
-    tilt (2.4.0)
+    tilt (2.3.0)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Reverts Scalingo/sample-ruby-sinatra#25

Deployment failed